### PR TITLE
Fix duplicate submit listeners in edit forms

### DIFF
--- a/tutor_manager.js
+++ b/tutor_manager.js
@@ -536,10 +536,17 @@ window.addEventListener("load", async () => {
       contact.value = studentToEdit.contact;
       notes.value = studentToEdit.notes;
 
-      editStudentForm.addEventListener("submit", (e) => {
-        saveStudentUpdate(studentToEdit)
+      const submitHandler = (e) => {
+        saveStudentUpdate(studentToEdit);
         e.preventDefault();
-      })
+      };
+
+      if (editStudentForm._submitHandler) {
+        editStudentForm.removeEventListener("submit", editStudentForm._submitHandler);
+      }
+
+      editStudentForm._submitHandler = submitHandler;
+      editStudentForm.addEventListener("submit", submitHandler, { once: true });
     }
 
     async function saveStudentUpdate(studentToEdit) {
@@ -827,10 +834,17 @@ window.addEventListener("load", async () => {
       notes.value = tutorToEdit.notes;
 
       const editTutorForm = document.getElementById("editTutorForm");
-      editTutorForm.addEventListener("submit", (e) => {
+      const submitHandler = (e) => {
         saveTutorUpdate(tutorToEdit);
         e.preventDefault();
-      });
+      };
+
+      if (editTutorForm._submitHandler) {
+        editTutorForm.removeEventListener("submit", editTutorForm._submitHandler);
+      }
+
+      editTutorForm._submitHandler = submitHandler;
+      editTutorForm.addEventListener("submit", submitHandler, { once: true });
     }
 
     async function saveTutorUpdate(tutorToEdit) {


### PR DESCRIPTION
## Summary
- prevent multiple submit listeners in edit forms by removing old listener before adding a new one and using `{ once: true }`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688bbcef69308328ac87d1c28a344ac1