### PR TITLE
Fix session ID handling for Firestore records

### DIFF
--- a/tutor_manager.js
+++ b/tutor_manager.js
@@ -62,7 +62,7 @@ window.addEventListener("load", async () => {
       events: [], // Will be populated dynamically
       editable: true, // Enable drag-and-drop
       eventDrop: function(info) {
-        const sessionId = parseInt(info.event.id);
+        const sessionId = info.event.id;
         const session = sessions.find(s => s.id === sessionId);
         if (session) {
           // Update session date and time
@@ -120,7 +120,7 @@ window.addEventListener("load", async () => {
         }
       },
       eventClick: function(info) {
-        const sessionId = parseInt(info.event.id);
+        const sessionId = info.event.id;
         const session = sessions.find(s => s.id === sessionId);
         if (session) {
           showSessionDetails(session);
@@ -339,7 +339,7 @@ window.addEventListener("load", async () => {
 
     document.getElementById("sessionTable").addEventListener("change", (e) => {
       if (e.target.type === "checkbox") {
-        const sessionId = parseInt(e.target.getAttribute("data-id"));
+        const sessionId = e.target.getAttribute("data-id");
         const sessionToUpdate = sessions.find((s) => s.id === sessionId);
         if (sessionToUpdate.status === "occurred") {
           sessionToUpdate.paid = e.target.checked;


### PR DESCRIPTION
## Summary
- handle Firestore session IDs as strings during drag/drop and click
- lookup sessions correctly when toggling paid status

## Testing
- `node --check tutor_manager.js`
- `node -e "const sessions = [{id: 'abc123', val: 1}, {id: 'def456', val: 2}]; const sessionId = 'abc123'; console.log(sessions.find(s => s.id === sessionId));"`

------
https://chatgpt.com/codex/tasks/task_e_688bbcee48748328bcdcb8c7acaf4b23